### PR TITLE
Add support for custom regions

### DIFF
--- a/Sources/S3.swift
+++ b/Sources/S3.swift
@@ -77,7 +77,14 @@ public class S3 {
             throw Error.missingCredentials("secretKey")
         }
         
-        self.init(accessKey: accessKey, secretKey: secretKey)
+        if let regionString: String = drop.config["s3", "region"]?.string {
+            guard let region = Region(rawValue: regionString) else {
+                throw Error.missingCredentials("region")
+            }
+            self.init(accessKey: accessKey, secretKey: secretKey, region: region)
+        } else {
+            self.init(accessKey: accessKey, secretKey: secretKey)
+        }
         
         if let bucket: String = drop.config["s3", "bucket"]?.string {
             self.bucketName = bucket
@@ -273,8 +280,7 @@ internal extension S3 {
             throw Error.missingBucketName
         }
         
-        var url: URL = URL(string: "https://s3.amazonaws.com")!
-        url.appendPathComponent(bucket!)
+        var url: URL = URL(string: "https://\(bucket!).s3.amazonaws.com")!
         url.appendPathComponent(fileName)
         return url
     }


### PR DESCRIPTION
Thanks for creating this! 🇨🇿

A couple of fixes for when running outside of the default bucket region:
- I added an option to set `region` in `s3.config` for when using a custom region, like Europe.
- I updated the S3 URL. My S3 bucket is running in European region, and requires the address to look like this. It should be universal now, but I'm no S3 expert.